### PR TITLE
POST-as-GET

### DIFF
--- a/src/ACMESharp.MockServer/Controllers/AcmeController.cs
+++ b/src/ACMESharp.MockServer/Controllers/AcmeController.cs
@@ -312,6 +312,24 @@ namespace ACMESharp.MockServer.Controllers
             return order.Details.Payload;
         }
 
+        [HttpPost("order/{acctId}/{orderId}")]
+        public ActionResult<Order> GetOrderPost(string acctId, string orderId, [FromBody]JwsSignedPayload signedPayload)
+        {
+            var ph = ExtractProtectedHeader(signedPayload);
+            ValidateNonce(ph);
+            var acct = _repo.GetAccountByKid(ph.Kid);
+            if (acct == null)
+                throw new Exception("could not resolve account");
+            ValidateAccount(acct, signedPayload);
+            var requ = ExtractPayload<string>(signedPayload);
+            if (requ != null)
+            {
+                return NotFound();
+            }
+            GenerateNonce();
+            return GetOrder(acctId, orderId);
+        }
+
         // "finalize": "https://acme-staging-v02.api.letsencrypt.org/acme/finalize/6294712/2084859"
         [HttpPost("finalize/{acctId}/{orderId}")]
         public ActionResult<Order> FinalizeOrder(string acctId, string orderId,
@@ -483,6 +501,24 @@ namespace ACMESharp.MockServer.Controllers
                 return NotFound();
             
             return dbAuthz.Payload;
+        }
+
+        [HttpPost("authz/{authzKey}")]
+        public ActionResult<Authorization> GetAuthorizationPost(string authzKey, [FromBody]JwsSignedPayload signedPayload)
+        {
+            var ph = ExtractProtectedHeader(signedPayload);
+            ValidateNonce(ph);
+            var acct = _repo.GetAccountByKid(ph.Kid);
+            if (acct == null)
+                throw new Exception("could not resolve account");
+            ValidateAccount(acct, signedPayload);
+            var requ = ExtractPayload<string>(signedPayload);
+            if (requ != null)
+            {
+                return NotFound();
+            }
+            GenerateNonce();
+            return GetAuthorization(authzKey);
         }
 
         [HttpGet("challenge/{authzKey}/{challengeId}")]

--- a/src/ACMESharp/Protocol/AcmeProtocolClient.cs
+++ b/src/ACMESharp/Protocol/AcmeProtocolClient.cs
@@ -675,7 +675,10 @@ namespace ACMESharp.Protocol
             CancellationToken cancel = default(CancellationToken))
         {
             var url = new Uri(_http.BaseAddress, relativeUrl);
-            var resp = await _http.GetAsync(url);
+            var method = _usePostAsGet ? HttpMethod.Post : HttpMethod.Get;
+            var message = _usePostAsGet ? "" : null;
+            var skipNonce = _usePostAsGet ? false : true;
+            var resp = await SendAcmeAsync(url, method, message, skipNonce: skipNonce, cancel: cancel);
             resp.EnsureSuccessStatusCode();
             return resp;
         }

--- a/test/ACMESharp.MockServer.UnitTests/AcmeControllerTests.cs
+++ b/test/ACMESharp.MockServer.UnitTests/AcmeControllerTests.cs
@@ -154,8 +154,10 @@ namespace ACMESharp.MockServer.UnitTests
             }
         }
 
+        [DataRow(true)]
+        [DataRow(false)]
         [TestMethod]
-        public async Task GetAuthz()
+        public async Task GetAuthz(bool usePostAsGet)
         {
             using (var http = _server.CreateClient())
             {
@@ -163,7 +165,7 @@ namespace ACMESharp.MockServer.UnitTests
                 var signer = new Crypto.JOSE.Impl.RSJwsTool();
                 signer.Init();
                 using (var acme = new AcmeProtocolClient(http, dir,
-                    signer: signer))
+                    signer: signer, usePostAsGet: usePostAsGet))
                 {
                     await acme.GetNonceAsync();
                     var acct = await acme.CreateAccountAsync(new[] { "mailto:foo@bar.com" });
@@ -254,8 +256,10 @@ namespace ACMESharp.MockServer.UnitTests
             }
         }
 
+        [DataRow(true)]
+        [DataRow(false)]
         [TestMethod]
-        public async Task GetChallenge()
+        public async Task GetChallenge(bool usePostAsGet)
         {
             using (var http = _server.CreateClient())
             {
@@ -263,7 +267,7 @@ namespace ACMESharp.MockServer.UnitTests
                 var signer = new Crypto.JOSE.Impl.RSJwsTool();
                 signer.Init();
                 using (var acme = new AcmeProtocolClient(http, dir,
-                    signer: signer))
+                    signer: signer, usePostAsGet: usePostAsGet))
                 {
                     await acme.GetNonceAsync();
                     var acct = await acme.CreateAccountAsync(new[] { "mailto:foo@bar.com" });


### PR DESCRIPTION
According to
- https://tools.ietf.org/html/rfc8555
- https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380

It's added as an optional feature enabled by a new boolean parameter to the constructor of the AcmeProtocolClient. As far as I could tell the new rules only needed to be applied to the following three functions:

- GetOrderDetailsAsync
- GetAuthorizationDetailsAsync
- GetChallengeDetailsAsync
- GetAsync

Tested against win-acme 2.0.10 and added some unit tests.