### PR TITLE
Issue: Example code used by ACMECLI resets KeySize for RSA algorithm

### DIFF
--- a/src/examples/Examples.Common.PKI/ExamplesAccountKey.cs
+++ b/src/examples/Examples.Common.PKI/ExamplesAccountKey.cs
@@ -24,7 +24,7 @@ namespace Examples.Common.PKI
             if (KeyType.StartsWith("RS"))
             {
                 var tool = new ACMESharp.Crypto.JOSE.Impl.RSJwsTool();
-                tool.KeySize = int.Parse(KeyType.Substring(2));
+                tool.HashSize = int.Parse(KeyType.Substring(2));
                 tool.Init();
                 tool.Import(KeyExport);
                 return tool;


### PR DESCRIPTION
Initialize HashSize, rather than KeySize when loading JwsAlg from local state storage.
