### PR TITLE
Exception handling for TOS retrieval

### DIFF
--- a/src/ACMESharp/Protocol/AcmeProtocolClient.cs
+++ b/src/ACMESharp/Protocol/AcmeProtocolClient.cs
@@ -145,14 +145,21 @@ namespace ACMESharp.Protocol
             if (tosUrl == null)
                 return (null, null, null);
 
-            using (var resp = await _http.GetAsync(tosUrl, cancel))
+            try
             {
-                var filename = resp.Content?.Headers?.ContentDisposition?.FileName;
-                if (string.IsNullOrEmpty(filename))
-                    filename = new Uri(tosUrl).AbsolutePath;
-                return (resp.Content.Headers.ContentType,
-                        Path.GetFileName(filename),
-                        await resp.Content.ReadAsByteArrayAsync());
+                using (var resp = await _http.GetAsync(tosUrl, cancel))
+                {
+                    var filename = resp.Content?.Headers?.ContentDisposition?.FileName;
+                    if (string.IsNullOrEmpty(filename))
+                        filename = new Uri(tosUrl).AbsolutePath;
+                    return (resp.Content.Headers.ContentType,
+                            Path.GetFileName(filename),
+                            await resp.Content.ReadAsByteArrayAsync());
+                }
+            } 
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving terms of service from {tosUrl}", ex);
             }
         }
 


### PR DESCRIPTION
It actually can fail (https://github.com/win-acme/win-acme/issues/1529) and at our level we "don't know" the URL that failed (obviously we could peek at the directory, but it's better handled like this I think.