### PR TITLE
Low-level work for alternative link certificates

### DIFF
--- a/src/ACMESharp/ACMESharp.csproj
+++ b/src/ACMESharp/ACMESharp.csproj
@@ -26,9 +26,9 @@
   <Import Project="../../version.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/ACMESharp/AcmeCertificate.cs
+++ b/src/ACMESharp/AcmeCertificate.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ACMESharp.HTTP;
+
+namespace ACMESharp
+{
+    public class AcmeCertificate
+    {
+        public byte[] Certificate { get; set; }
+        public LinkCollection Links { get; set; }
+    }
+}

--- a/src/ACMESharp/Crypto/JOSE/JwsHelper.cs
+++ b/src/ACMESharp/Crypto/JOSE/JwsHelper.cs
@@ -91,7 +91,7 @@ namespace ACMESharp.Crypto.JOSE
                 object protectedHeaders = null, object unprotectedHeaders = null)
         {
             var jwsFlatJS = SignFlatJsonAsObject(sigFunc, payload, protectedHeaders, unprotectedHeaders);
-            return JsonConvert.SerializeObject(jwsFlatJS, Formatting.Indented);
+            return JsonConvert.SerializeObject(jwsFlatJS, Formatting.None);
         }
 
         /// <summary>

--- a/src/ACMESharp/Protocol/AcmeProtocolClient.cs
+++ b/src/ACMESharp/Protocol/AcmeProtocolClient.cs
@@ -194,7 +194,8 @@ namespace ACMESharp.Protocol
         /// <remarks>
         /// https://tools.ietf.org/html/draft-ietf-acme-acme-12#section-7.3
         /// </remarks>
-        public async Task<AccountDetails> CreateAccountAsync(IEnumerable<string> contacts,
+        public async Task<AccountDetails> CreateAccountAsync(
+            IEnumerable<string> contacts = null,
             bool termsOfServiceAgreed = false,
             object externalAccountBinding = null,
             bool throwOnExistingAccount = false,

--- a/src/ACMESharp/Protocol/AcmeProtocolClient.cs
+++ b/src/ACMESharp/Protocol/AcmeProtocolClient.cs
@@ -645,6 +645,28 @@ namespace ACMESharp.Protocol
         }
 
         /// <summary>
+        /// Get ACME certificate including metadata
+        /// </summary>
+        /// <param name="order"></param>
+        /// <param name="cancel"></param>
+        /// <returns></returns>
+        public async Task<AcmeCertificate> GetOrderCertificateExAsync(
+            OrderDetails order,
+            CancellationToken cancel = default)
+        {
+            using (var resp = await GetAsync(order.Payload.Certificate, cancel))
+            {
+                var ret = new AcmeCertificate();
+                if (resp.Headers.TryGetValues("Link", out var linkValues))
+                {
+                    ret.Links = new HTTP.LinkCollection(linkValues);
+                }
+                ret.Certificate = await resp.Content.ReadAsByteArrayAsync();
+                return ret;
+            }
+        }
+
+        /// <summary>
         /// Revoke certificate
         /// </summary>
         /// <remarks>

--- a/src/ACMESharp/Protocol/Messages/CreateAccountRequest.cs
+++ b/src/ACMESharp/Protocol/Messages/CreateAccountRequest.cs
@@ -10,8 +10,7 @@ namespace ACMESharp.Protocol.Messages
     /// </summary>
     public class CreateAccountRequest
     {
-        [JsonProperty("contact", Required = Required.Always)]
-        [Required, MinLength(1)]
+        [JsonProperty("contact", NullValueHandling=NullValueHandling.Ignore)]
         public IEnumerable<string> Contact { get; set; }
 
         [JsonProperty("termsOfServiceAgreed", NullValueHandling=NullValueHandling.Ignore)]


### PR DESCRIPTION
For the upcoming change in intermediate certificate, some clients may need to issue an alternative certificate for legacy system (e.g. older Android releases). https://community.letsencrypt.org/t/transition-to-isrgs-root-delayed-until-jan-11-2021/125516

This patch adds some low level plumbing for clients to be able to retrieve those alternate urls.