### PR TITLE
Remove indentation from the request payload JSON

### DIFF
--- a/src/ACMESharp/Crypto/JOSE/JwsHelper.cs
+++ b/src/ACMESharp/Crypto/JOSE/JwsHelper.cs
@@ -91,7 +91,7 @@ namespace ACMESharp.Crypto.JOSE
                 object protectedHeaders = null, object unprotectedHeaders = null)
         {
             var jwsFlatJS = SignFlatJsonAsObject(sigFunc, payload, protectedHeaders, unprotectedHeaders);
-            return JsonConvert.SerializeObject(jwsFlatJS, Formatting.Indented);
+            return JsonConvert.SerializeObject(jwsFlatJS);
         }
 
         /// <summary>


### PR DESCRIPTION
Believe it or not, some ACME implementations return an error if there is indentation in the JSON of the request payload.
https://github.com/win-acme/win-acme/issues/1565

I noticed this problem in the ACME implementation of ZeroSSL.