### PR TITLE
Changed the type of ExternalAccountRequired property to bool

### DIFF
--- a/src/ACMESharp/Protocol/Resources/ServiceDirectory.cs
+++ b/src/ACMESharp/Protocol/Resources/ServiceDirectory.cs
@@ -60,6 +60,6 @@ namespace ACMESharp.Protocol.Resources
         public string[] CaaIdentities { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string ExternalAccountRequired { get; set; }
+        public bool? ExternalAccountRequired { get; set; }
     }
 }


### PR DESCRIPTION
Since the value of the `ExternalAccountRequired` property is specified as boolean, it has been changed to `bool?` to take null into account.

>externalAccountRequired | boolean
https://www.iana.org/assignments/acme/acme.xhtml#acme-directory-metadata-fields